### PR TITLE
Text input component

### DIFF
--- a/src/components/TextInput/index.tsx
+++ b/src/components/TextInput/index.tsx
@@ -1,14 +1,19 @@
 import * as React from 'react';
-import { Component } from './style';
+import { Component, StyledInput, ErrorLabel } from './style';
 import { InputType, inputTagType, validateEmail } from '../../services';
 
 export interface TextInputProps {
-  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onChange: (text: string) => void;
   className?: string;
   type?: InputType;
   placeholder?: string;
   value?: string;
   shouldFill?: boolean;
+}
+
+enum ErrorMessage {
+  VOID_VALUE = '필수 입력 값입니다',
+  NOT_EMAIL_FORMAT = '이메일 형식으로 작성해주세요',
 }
 
 const TextInput: React.FunctionComponent<TextInputProps> = ({
@@ -19,21 +24,31 @@ const TextInput: React.FunctionComponent<TextInputProps> = ({
   value = '',
   shouldFill = false,
 }) => {
-  const checkValid = (): boolean => {
-    if (shouldFill) return !!value;
-    if (type === 'email' && value) return validateEmail(value);
-    return true;
+  const checkValid = (): string => {
+    if (shouldFill && !value) return ErrorMessage.VOID_VALUE;
+    if (type === 'email' && value) {
+      if (!validateEmail(value)) {
+        return ErrorMessage.NOT_EMAIL_FORMAT;
+      }
+    }
+    return '';
   };
 
+  const handleOnchage = ({
+    target: { value },
+  }: React.ChangeEvent<HTMLInputElement>) => onChange(value);
+
   return (
-    <Component
-      onChange={onChange}
-      className={className}
-      placeholder={placeholder}
-      value={value}
-      isError={!checkValid()}
-      type={inputTagType(type)}
-    />
+    <Component>
+      <ErrorLabel>{checkValid()}</ErrorLabel>
+      <StyledInput
+        onChange={handleOnchage}
+        className={className}
+        placeholder={placeholder}
+        value={value}
+        type={inputTagType(type)}
+      />
+    </Component>
   );
 };
 

--- a/src/components/TextInput/style.ts
+++ b/src/components/TextInput/style.ts
@@ -1,11 +1,18 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import { Theme } from '../../globalStyle';
 
-interface ComponentProps {
-  isError: boolean;
-}
+export const Component = styled.div`
+  margin-bottom: 20px;
+`;
 
-export const Component = styled.input`
+export const ErrorLabel = styled.div`
+  margin-bottom: 10px;
+  height: 13px;
+  font-size: 13px;
+  color: ${Theme.MAIN_COLOR2};
+`;
+
+export const StyledInput = styled.input`
   display: block;
   width: 100%;
   border-radius: 10px;
@@ -16,6 +23,7 @@ export const Component = styled.input`
   border-color: ${Theme.MAIN_COLOR4};
   background-color: ${Theme.MAIN_COLOR4};
   color: #fff;
+  transition: 0.1s;
 
   &::placeholder {
     color: ${Theme.MAIN_COLOR2};
@@ -24,18 +32,4 @@ export const Component = styled.input`
     background-color: ${Theme.MAIN_COLOR4};
     border-color: ${Theme.MAIN_COLOR3};
   }
-
-  ${({ isError }: ComponentProps) => {
-    return (
-      isError &&
-      css`
-        background-color: ${Theme.ERROR_COLOR1};
-        border-color: ${Theme.ERROR_COLOR1};
-        color: ${Theme.ERROR_COLOR2};
-        &::placeholder {
-          color: ${Theme.ERROR_COLOR2};
-        }
-      `
-    );
-  }}
 `;


### PR DESCRIPTION
text input의 컴포넌트 props onChange에서 event객체를 전달하지않고 변경된 텍스트를 보내줍니다.
추가로 스타일을 변경했습니다. 입력텍스트에 에러가 발생하면(이메일 정규식에 틀리거나, 값이 비어있거나) 빨간색으로 바꿔주었는데 이걸 인풋 엘리먼트위 라벨을 붙여서 알수 있도록했습니다.
왜냐면 빨간색으로 바꾸는건 디자인이 개똥임.